### PR TITLE
Change CMD -> Entrypoint in the docker build-release definition

### DIFF
--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -53,4 +53,4 @@ RUN go build
 FROM debian:buster as release
 
 COPY --from=builder /app/cmd/example-check/example-check /example-check
-CMD ["/example-check"]
+ENTRYPOINT ["/example-check"]


### PR DESCRIPTION
Ciao Nani!

I think the change you did in the first implementation makes a lot of sense.
Changing the CMD for ENTRYPOINT in the build-release target makes a lot of sense to me

So let's apply it to the project template!