### PR TITLE
Add linter configuration

### DIFF
--- a/.rules/.golangci.yml
+++ b/.rules/.golangci.yml
@@ -13,6 +13,8 @@
 run:
   # include test files or not, default is true
   tests: false
+  # timeout for analysis, e.g. 30s, 5m, default is 1m
+  timeout: 10m
 
 # configure golangci-lint
 # see https://github.com/golangci/golangci-lint/blob/master/.golangci.example.yml
@@ -20,30 +22,50 @@ issues:
   exclude-rules:
     - path: _test\.go
       linters:
-      - dupl
-      - gosec
-      - goconst
+        - dupl
+        - goconst
+    - path: cmd/
+      linters:
+        - gochecknoinits
+        - lll
+    - path: cmd/example-check/main.go
+      linters:
+        - gochecknoglobals
 linters:
+  disable-all: true
   enable:
-    - golint
-    - gosec
-    - unconvert
-    - gocyclo
+    - ineffassign
+    - asciicheck
+    - dogsled
+    - dupl
+    - funlen
+    - gci
+    - gochecknoglobals
+    - gochecknoinits
+    - gocognit
     - goconst
+    - gocyclo
+    - godot
+    - godox
+    - gofmt
+    - goheader
     - goimports
-    - maligned
-    - gocritic
+    - gomnd
+    - gomodguard
+    - goprintffuncname
+    - lll
+    - misspell
+    - nakedret
+    - nestif
+    - nlreturn
+    - nolintlint
+    - prealloc
+    - scopelint
+    - testpackage
+    - whitespace
+    - wsl
+
 linters-settings:
-  errcheck:
-    # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`;
-    # default is false: such cases aren't reported by default.
-    check-blank: true
-  govet:
-    # report about shadowed variables
-    check-shadowing: true
   gocyclo:
     # minimal code complexity to report, 30 by default
     min-complexity: 15
-  maligned:
-    # print struct with more effective memory layout or not, false by default
-    suggest-new: true

--- a/.rules/.golangci.yml
+++ b/.rules/.golangci.yml
@@ -64,6 +64,7 @@ linters:
     - testpackage
     - whitespace
     - wsl
+    - revive
 
 linters-settings:
   gocyclo:

--- a/.rules/.jscpd.json
+++ b/.rules/.jscpd.json
@@ -1,0 +1,11 @@
+{
+  "threshold": 0,
+  "reporters": [
+    "consoleFull"
+  ],
+  "ignore": [
+    "/**/**_test.go",
+    "/**/**.md"
+  ],
+  "absolute": true
+}


### PR DESCRIPTION
With this PR I am trying to address an extended configuration of the linters.

- golang-ci: I've configured a more strict behaviour with the limitations that the `policeman`/`super-linter` runs in a single file mode. As an example, with the previous config was an issue with private functions invocation from the same package.
- jscpd: Checks for copy/pastes. I configured it to exclude markdown files and go `test` files. 

Thanks!