### PR TITLE
Implement make clean target

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -20,6 +20,8 @@ steps:
         apk add make bash util-linux
       - &target
         make $${DRONE_STEP_NAME}
+      - &clean-target
+        make clean-$${DRONE_STEP_NAME}
 
   - <<: *docker-test
     name: lint
@@ -50,6 +52,7 @@ steps:
       - unzip -d /tmp /tmp/temp.zip
       - /tmp/bats-core-$${BATS_VERSION}/install.sh /usr/local
       - *target
+      - make clean-build-release
 
   - <<: *docker-test
     name: publish
@@ -66,6 +69,7 @@ steps:
       - export IMAGE_NAME=$${DRONE_REPO_NAME}
       - export IMAGE_TAG=$${DRONE_TAG:-unstable}
       - *target
+      - make clean-build-release
     when:
       event:
         exclude:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,7 @@ $ make
   license         Check license headers are in-place in all files in the project
   e2e-test        Execute e2e-tests. CLUSTER_VERSION=v1.21.1 make e2e-test
   publish         Publish the container image
+  clean-%         Clean the container image resulting from another target. make build clean-build
 
 ```
 
@@ -183,6 +184,20 @@ In order to use this target you may need to specify a set of variables:
 ```bash
 REGISTRY_USER=angelbarrera92 IMAGE_TAG=latest IMAGE_NAME=sighupio/example-check REGISTRY_PASSWORD=supersuperrarepasswordeh REGISTRY=registry.sighup.io make publish
 ```
+
+### clean-%v
+
+The `clean-%v` target has been designed to remove the local built image resulting from the different targets in the
+[`Makefile`](Makefile).
+
+The main reason to implement this target is to save disk space.
+
+Example usages:
+
+- `make build clean-build`
+- `make lint clean-lint`
+- `make license clean-license`
+- `make test clean-test`
 
 ## Pipeline
 

--- a/Makefile
+++ b/Makefile
@@ -56,3 +56,7 @@ e2e-test: check-variable-CLUSTER_VERSION check-docker check-kind check-kubectl c
 ## publish: Publish the container image
 publish: check-variable-REGISTRY check-variable-REGISTRY_USER check-variable-REGISTRY_PASSWORD check-variable-IMAGE_NAME check-variable-IMAGE_TAG check-docker build-release
 	@./scripts/publish/run.sh ${PROJECTNAME}:local-build-release ${REGISTRY} ${REGISTRY_USER} ${REGISTRY_PASSWORD} ${IMAGE_NAME} ${IMAGE_TAG}
+
+## clean-%: Clean the container image resulting from another target. make build clean-build
+clean-%:
+	@docker rmi -f ${PROJECTNAME}:local-${*}

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ $ make
   license         Check license headers are in-place in all files in the project
   e2e-test        Execute e2e-tests. CLUSTER_VERSION=v1.21.1 make e2e-test
   publish         Publish the container image
+  clean-%         Clean the container image resulting from another target. make build clean-build
+
 ```
 
 All these make targets are also available in form of (drone) pipeline.


### PR DESCRIPTION
As we are struggling with the disk usage, it is worthy to implement this kind of `clean` target.
As this repo is a project template, I've added both the `Makefile` clean target and configured it in the default/template pipeline.

The idea behind this target is to use it along with the previous targets:

- `make build clean-build`
- `make lint clean-lint`
- `make test clean-test`

And so on