### PR TITLE
New helpful Makefile targets

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -20,8 +20,6 @@ steps:
         apk add make bash util-linux
       - &target
         make $${DRONE_STEP_NAME}
-      - &clean-target
-        make clean-$${DRONE_STEP_NAME}
 
   - <<: *docker-test
     name: lint
@@ -52,7 +50,6 @@ steps:
       - unzip -d /tmp /tmp/temp.zip
       - /tmp/bats-core-$${BATS_VERSION}/install.sh /usr/local
       - *target
-      - make clean-build-release
 
   - <<: *docker-test
     name: publish
@@ -69,7 +66,6 @@ steps:
       - export IMAGE_NAME=$${DRONE_REPO_NAME}
       - export IMAGE_TAG=$${DRONE_TAG:-unstable}
       - *target
-      - make clean-build-release
     when:
       event:
         exclude:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,10 +18,13 @@ $ make
 
   init            Init the project. GITHUB_PROJECT=demo make init
   drone-init      Init the drone-project. GITHUB_PROJECT=demo GITHUB_TOKEN=123token321 DRONE_TOKEN=tokenhere REGISTRY=registry.sighup.io REGISTRY_USER=robotuser REGISTRY_PASSWORD=thepassword make drone-init
+  embedme         Run embedme to render and embed markdown files
+  render          Render the default kustomization project into the examples directory
   build           Build the container image
   lint            Run the policeman over the repository
   build-release   Build the release container image
   test            Run unit testing
+  add-license     Add license headers in all files in the project
   license         Check license headers are in-place in all files in the project
   e2e-test        Execute e2e-tests. CLUSTER_VERSION=v1.21.1 make e2e-test
   publish         Publish the container image
@@ -55,6 +58,16 @@ Project already initialized with name demo-check
 It automates the configuration of the drone project with a single command, it requires a privilege token to run it.
 If you don't have it, read more about how to set up it manually
 [in the docs](https://github.com/sighupio/fip-healthcheck-go-template)
+
+### embedme
+
+This target runs the [embedme](https://github.com/zakhenry/embedme) utility to embed possible files in markdown files.
+The [`lint`](#lint) target checks if `embedme` has changes to do.
+
+### render
+
+This target (re)generates a couple of kubernetes manifests files from two different kustomize projects.
+Find the output of this target in the [examples](examples) directory.
 
 ### build
 
@@ -146,6 +159,11 @@ RUN mkdir /app
 ```
 
 Currently it executes `go test ./...` but feel free to modify with the right command.
+
+### add-license
+
+`add-license` target avoids you to have installed the [addlicense](https://github.com/google/addlicense) binary so
+it adds the license to every file using a specific container.
 
 ### license
 

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ license: check-docker
 	@$(MAKE) clean-license
 
 ## e2e-test: Execute e2e-tests. CLUSTER_VERSION=v1.21.1 make e2e-test
-e2e-test: check-variable-CLUSTER_VERSION check-docker check-kind check-kubectl check-bats check-jq check-kustomize build-release
+e2e-test: check-variable-CLUSTER_VERSION check-docker check-kind check-kubectl check-bats check-kustomize build-release
 	@./scripts/e2e/run.sh ${PROJECTNAME}:local-build-release ${CLUSTER_VERSION}
 	@$(MAKE) clean-build-release
 

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 SHELL := /bin/bash
 
 PROJECTNAME := "fip-healthcheck-go-template"
+ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 .PHONY: help
 all: help
@@ -29,13 +30,31 @@ init: check-variable-GITHUB_PROJECT
 drone-init: check-variable-GITHUB_PROJECT check-variable-GITHUB_TOKEN check-variable-DRONE_TOKEN check-variable-REGISTRY check-variable-REGISTRY_USER check-variable-REGISTRY_PASSWORD
 	@test -f ./scripts/drone-init.sh && ./scripts/drone-init.sh ${GITHUB_PROJECT} ${GITHUB_TOKEN} ${DRONE_TOKEN} ${REGISTRY} ${REGISTRY_USER} ${REGISTRY_PASSWORD} || echo "Drone project already initialized with name ${GITHUB_PROJECT}"
 
+requirements: check-docker
+	@docker build --no-cache --pull --target requirements -f build/builder/Dockerfile -t ${PROJECTNAME}:requirements .
+
+npm-requirements: check-docker
+	@docker build --no-cache --pull --target npm-requirements -f build/builder/Dockerfile -t ${PROJECTNAME}:npm-requirements .
+
+## embedme: Run embedme to render and embed markdown files
+embedme: npm-requirements
+	@docker run --rm -v ${ROOT_DIR}:/app -w /app ${PROJECTNAME}:npm-requirements embedme "**/*.md"
+	@$(MAKE) add-license
+
+## render: Render the default kustomization project into the examples directory
+render: check-kustomize
+	@kustomize build deployments/kustomization > examples/rendered.yaml
+	@$(MAKE) add-license
+
 ## build: Build the container image
 build: check-docker
 	@docker build --no-cache --pull --target builder -f build/builder/Dockerfile -t ${PROJECTNAME}:local-build .
+	@$(MAKE) clean-build
 
 ## lint: Run the policeman over the repository
 lint: check-docker
 	@docker build --no-cache --pull --target linter -f build/builder/Dockerfile -t ${PROJECTNAME}:local-lint .
+	@$(MAKE) clean-lint
 
 ## build-release: Build the release container image
 build-release: check-docker
@@ -44,39 +63,27 @@ build-release: check-docker
 ## test: Run unit testing
 test: check-docker
 	@docker build --no-cache --pull --target tester -f build/builder/Dockerfile -t ${PROJECTNAME}:local-test .
-
-## license: Check license headers are in-place in all files in the project
-license: check-docker
-	@docker build --no-cache --pull --target license -f build/builder/Dockerfile -t ${PROJECTNAME}:local-license .
-
-## e2e-test: Execute e2e-tests. CLUSTER_VERSION=v1.21.1 make e2e-test
-e2e-test: check-variable-CLUSTER_VERSION check-docker check-kind check-kubectl check-bats check-kustomize build-release
-	@./scripts/e2e/run.sh ${PROJECTNAME}:local-build-release ${CLUSTER_VERSION}
-
-## publish: Publish the container image
-publish: check-variable-REGISTRY check-variable-REGISTRY_USER check-variable-REGISTRY_PASSWORD check-variable-IMAGE_NAME check-variable-IMAGE_TAG check-docker build-release
-	@./scripts/publish/run.sh ${PROJECTNAME}:local-build-release ${REGISTRY} ${REGISTRY_USER} ${REGISTRY_PASSWORD} ${IMAGE_NAME} ${IMAGE_TAG}
-
-## clean-%: Clean the container image resulting from another target. make build clean-build
-clean-%:
-	@docker rmi -f ${PROJECTNAME}:local-${*}
-
-npm-requirements: check-docker
-	@docker build --no-cache --pull --target npm-requirements -f build/builder/Dockerfile -t ${PROJECTNAME}:npm-requirements .
-
-requirements: check-docker
-	@docker build --no-cache --pull --target requirements -f build/builder/Dockerfile -t ${PROJECTNAME}:requirements .
-
-## embedme: Run embedme
-embedme: npm-requirements
-	@docker run --rm -v ${ROOT_DIR}:/app -w /app ${PROJECTNAME}:npm-requirements embedme "**/*.md"
-	@$(MAKE) add-license
+	@$(MAKE) clean-test
 
 ## add-license: Add license headers in all files in the project
 add-license: requirements
 	@docker run --rm -v ${ROOT_DIR}:/app -w /app ${PROJECTNAME}:requirements addlicense -c "SIGHUP s.r.l" -v -l bsd .
 
-## render: Render examples
-render: check-kustomize
-	@kustomize build deployments/kustomization > examples/rendered.yaml
-	@$(MAKE) add-license
+## license: Check license headers are in-place in all files in the project
+license: check-docker
+	@docker build --no-cache --pull --target license -f build/builder/Dockerfile -t ${PROJECTNAME}:local-license .
+	@$(MAKE) clean-license
+
+## e2e-test: Execute e2e-tests. CLUSTER_VERSION=v1.21.1 make e2e-test
+e2e-test: check-variable-CLUSTER_VERSION check-docker check-kind check-kubectl check-bats check-jq check-kustomize build-release
+	@./scripts/e2e/run.sh ${PROJECTNAME}:local-build-release ${CLUSTER_VERSION}
+	@$(MAKE) clean-build-release
+
+## publish: Publish the container image
+publish: check-variable-REGISTRY check-variable-REGISTRY_USER check-variable-REGISTRY_PASSWORD check-variable-IMAGE_NAME check-variable-IMAGE_TAG check-docker build-release
+	@./scripts/publish/run.sh ${PROJECTNAME}:local-build-release ${REGISTRY} ${REGISTRY_USER} ${REGISTRY_PASSWORD} ${IMAGE_NAME} ${IMAGE_TAG}
+	@$(MAKE) clean-build-release
+
+## clean-%: Clean the container image resulting from another target. make build clean-build
+clean-%:
+	@docker rmi -f ${PROJECTNAME}:local-${*}

--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -2,6 +2,14 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
+FROM golang:1.16 as requirements
+
+RUN go get -u github.com/google/addlicense
+
+FROM docker.io/library/node:14 as npm-requirements
+
+RUN npm install -g embedme@1.22.0
+
 # hadolint ignore=DL3007
 FROM quay.io/sighup/policeman:latest as linter
 
@@ -12,7 +20,7 @@ WORKDIR /app
 
 COPY . .
 
-RUN /entrypoint.sh
+RUN npm install -g embedme@1.22.0 && /entrypoint.sh && embedme --verify "**/*.md"
 
 FROM golang:1.16 as license
 

--- a/deployments/kustomization/README.md
+++ b/deployments/kustomization/README.md
@@ -12,7 +12,13 @@ $ kustomize build . | kubectl apply -f -
 
 The contents of the `kustomization` file are as follows:
 
+<!-- embedme kustomization.yaml -->
+
 ```yaml
+# Copyright (c) 2021 SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+#
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -21,7 +27,8 @@ resources:
   - cronjob.yaml
 configMapGenerator:
   - name: tbd-envs
-    env: .env
+    envs:
+      - env_template
 
 ```
 
@@ -71,9 +78,9 @@ to inject data into a pod.
 The environment variables necessary for the pod to execute are:
 
 ```yaml
-TND_SERVICE
-TND_NAMESPACE
-TND_MIN_EP
+TBD_SERVICE
+TBD_NAMESPACE
+TBD_MIN_EP
 ```
 
 Refer the [CLI usage guide for detailed review of
@@ -98,28 +105,18 @@ kustomize section is used:
 ``` yaml
 configMapGenerator:
 - name: tbd-envs
-  env: .env
+  envs:
+    - env_template
 ```
 
 Here a tbd-envs configMap Kubernetes resource is created from an environment
-file called `.env`. A template to this file is provided as a file
-`env_template`. The file has two keys defined with values left empty. So the
-first step would be to rename it as `.env` since that is what `kustomization`
-expects.
+file called `env_template`. The file has two keys defined with default values.
 
-``` yaml
-$ cp env_template .env
-$ cat .env
+<!-- embedme env_template -->
+
+```sh
 TBD_SERVICE=
 TBD_NAMESPACE=
 TBD_MIN_EP=
-```
 
-Add the values for the above 3 environment variables. An example could be:
-
-```yaml
-$ cat .env
-TBD_SERVICE=nginx
-TBD_NAMESPACE=dev
-TBD_MIN_EP=2
 ```

--- a/deployments/kustomization/kustomization.yaml
+++ b/deployments/kustomization/kustomization.yaml
@@ -11,4 +11,4 @@ resources:
 configMapGenerator:
   - name: tbd-envs
     envs:
-      - .env
+      - env_template

--- a/examples/rendered.yaml
+++ b/examples/rendered.yaml
@@ -1,0 +1,72 @@
+# Copyright (c) 2021 SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: example-check
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: example-check
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - watch
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: example-check
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: example-check
+subjects:
+- kind: ServiceAccount
+  name: example-check
+---
+apiVersion: v1
+data:
+  TBD_MIN_EP: ""
+  TBD_NAMESPACE: ""
+  TBD_SERVICE: ""
+kind: ConfigMap
+metadata:
+  name: tbd-envs-tdtgt687gm
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: example-check
+spec:
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - envFrom:
+            - configMapRef:
+                name: tbd-envs-tdtgt687gm
+            image: registry.sighup.io/poc/example-check:unstable
+            imagePullPolicy: IfNotPresent
+            name: example-check
+          restartPolicy: OnFailure
+          securityContext:
+            fsGroup: 999
+            runAsGroup: 999
+            runAsUser: 1001
+          serviceAccountName: example-check
+  schedule: '*/1 * * * *'
+  startingDeadlineSeconds: 10
+  successfulJobsHistoryLimit: 3

--- a/scripts/drone-init.sh
+++ b/scripts/drone-init.sh
@@ -11,6 +11,17 @@ REGISTRY=${4}
 REGISTRY_USER=${5}
 REGISTRY_PASSWORD=${6}
 
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    SED_BINARY="sed"
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+    SED_BINARY="gsed"
+else
+    echo "$OSTYPE Not supported"
+    exit 2
+fi
+
+which "${SED_BINARY}" > /dev/null || (echo "*** Please install ${SED_BINARY} ***" && exit 1)
+
 echo "Initializing repository for ${GITHUB_PROJECT}"
 echo " Configuring drone project @ ci.sighup.io"
 echo "  Waiting 30s to discover the newest repositories"
@@ -25,6 +36,8 @@ curl --fail -s -X POST -H "Content-Type: application/json" -H "Authorization: Be
 curl --fail -s -X POST -H "Content-Type: application/json" -H "Authorization: Bearer ${DRONE_TOKEN}" --data '{"name":"REGISTRY","data":"'"${REGISTRY}"'", "pull_request": false}' "https://ci.sighup.io/api/repos/${GITHUB_OWNER}/${GITHUB_PROJECT}/secrets"
 curl --fail -s -X POST -H "Content-Type: application/json" -H "Authorization: Bearer ${DRONE_TOKEN}" --data '{"name":"REGISTRY_USER","data":"'"${REGISTRY_USER}"'", "pull_request": false}' "https://ci.sighup.io/api/repos/${GITHUB_OWNER}/${GITHUB_PROJECT}/secrets"
 curl --fail -s -X POST -H "Content-Type: application/json" -H "Authorization: Bearer ${DRONE_TOKEN}" --data '{"name":"REGISTRY_PASSWORD","data":"'"${REGISTRY_PASSWORD}"'", "pull_request": false}' "https://ci.sighup.io/api/repos/${GITHUB_OWNER}/${GITHUB_PROJECT}/secrets"
+echo "  Remove drone-init target"
+${SED_BINARY} -i '/drone-init/d' Makefile
 echo "  Removing this script"
 rm -rf "${0}"
 

--- a/scripts/e2e/tests.sh
+++ b/scripts/e2e/tests.sh
@@ -26,15 +26,6 @@ info(){
     [ "$status" -eq 0 ]
 }
 
-@test "Prepare deploy" {
-    info
-    prep(){
-        cp deployments/kustomization/env_template deployments/kustomization/.env
-    }
-    run prep
-    [ "$status" -eq 0 ]
-}
-
 @test "Deploy" {
     info
     deploy(){

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -30,6 +30,10 @@ mv internal/example-check internal/"${GITHUB_PROJECT}"
 mv pkg/example-check pkg/"${GITHUB_PROJECT}"
 echo "  Removing template docs"
 rm -rf docs/template
+echo "  Remove init target"
+${SED_BINARY} -i '/Init the project/d' Makefile
+${SED_BINARY} -i '/^init:.*/d' Makefile
+${SED_BINARY} -i '/\"Project already/d' Makefile
 echo "  Removing this script"
 rm -rf "${0}"
 


### PR DESCRIPTION
Hi team!

I wanted to push some changes I've implemented in another project that I found useful:

- "Automatic" clean container images. From pipeline to Make target. It enhances the user experience while developing locally. 
- embedme: @lzecca78 shows us this tool. I wanted to make it working from the template repository.
  - It also checks during the `lint` target/pipeline step that the documentation is up to date.
- `init` and `drone-init` target disappears after usage. 
- `add-license` target was added to make it simpler to add a license header to all files in the project.
- add `render` target to create a rendered file from the default `kustomization` project.

I've updated also some docs to talk about 🔝 changes.