### PR TITLE
RBAC RoleBinding apiversion from v1beta1 -> v1

### DIFF
--- a/deployments/kustomization/role-binding.yaml
+++ b/deployments/kustomization/role-binding.yaml
@@ -12,7 +12,7 @@ rules:
   resources: ["services", "endpoints", "pods"]
   verbs: ["get", "watch", "list"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: example-check


### PR DESCRIPTION
I see this API being deprecated, i move it from v1beta1 to v1