### PR TITLE
Add config as struct instead of plain variables

### DIFF
--- a/cmd/example-check/main.go
+++ b/cmd/example-check/main.go
@@ -8,13 +8,14 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/sighupio/fip-healthcheck-go-template/internal/config"
 	internal "github.com/sighupio/fip-healthcheck-go-template/internal/example-check"
 	pkg "github.com/sighupio/fip-healthcheck-go-template/pkg/example-check"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
-var logLevel string
+var cfg = &config.CheckConfig{}
 
 var rootCmd = &cobra.Command{
 	PersistentPreRunE: cmdConfig,
@@ -29,26 +30,26 @@ var rootCmd = &cobra.Command{
 }
 
 func cmdConfig(cmd *cobra.Command, args []string) error {
-	lvl, err := log.ParseLevel(logLevel)
+	lvl, err := log.ParseLevel(cfg.LogLevel)
 	if err != nil {
-		log.WithField("log-level", logLevel).Fatal("incorrect log level")
+		log.WithField("log-level", cfg.LogLevel).Fatal("incorrect log level")
 
 		return fmt.Errorf("incorrect log level")
 	}
 
 	log.SetLevel(lvl)
-	log.WithField("log-level", logLevel).Debug("log level configured")
+	log.WithField("log-level", cfg.LogLevel).Debug("log level configured")
 
 	return nil
 }
 
 func init() {
-	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "logging level (debug, info...)")
+	rootCmd.PersistentFlags().StringVar(&cfg.LogLevel, "log-level", "info", "logging level (debug, info...)")
 }
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		log.WithError(err).Fatal("error in the cli. Exiting")
 		os.Exit(1)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,10 @@
+// Copyright (c) 2021 SIGHUP s.r.l All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package config
+
+// CheckConfig hosts the configuration of the application.
+type CheckConfig struct {
+	LogLevel string
+}


### PR DESCRIPTION
I see most of our projects uses structs to host configuration variables.
I've added a default struct to host configuration parameters.

